### PR TITLE
Fix broken inline install when fullscreen.

### DIFF
--- a/templates/head.html
+++ b/templates/head.html
@@ -39,8 +39,19 @@
     };
 
     var chromeinstall = function(e) {
+      
+      // If Chrome is fullscreen, inline install will fail with no message to user.
+      // So test for fullscreen mode. If we are fullscreen, give up on JS approach.
+      // Browser will follow link to the web store defined in the link's href attr.
+      if( window.outerHeight == screen.height) {
+        console.log("chrome is in fullscreen view. Quitting inline install.")
+        return false
+      }   
+
       e.preventDefault();
       chrome.webstore.install(undefined, function() { window.location = window.location.href }, function(err) { console.log('install error'); console.log(err); });
+
+      
     }
     if ( $('#chromeinstall').length ) $('#chromeinstall').on('click',chromeinstall);
     if ( $('.chromeinstall').length ) $('.chromeinstall').on('click',chromeinstall);


### PR DESCRIPTION
The online install currently dies when Chrome is in fullscreen mode, with no feedback to user. This provides fix. Falls back to the link to the webstore already defined in the link href attribute.

Not tested locally.