### PR TITLE
added a curl one liner for availability API example.

### DIFF
--- a/content/api.html
+++ b/content/api.html
@@ -101,6 +101,10 @@
         url, doi, pmc, pmid, title, citation.
       </p>
       <p>
+        A simple way to make a request to the availability API is the following one liner where YOURURL is your "url" paremeter:
+        curl -H "x-apikey: yourRegisteredApikey" -X GET "https://api.openaccessbutton.org/availability?url=YOURURL"
+      </p>
+      <p>
         The response returned lists objects of any "availability" found, with each object declaring "type" (currently either article or data)
         and the "url" where this object is found.
       </p>


### PR DESCRIPTION
A little example for availability api based on this [issue](https://github.com/OAButton/discussion/issues/1002).