### PR TITLE
Fix typo: alongslide -> alongside

### DIFF
--- a/content/about.html
+++ b/content/about.html
@@ -104,7 +104,7 @@
       The Open Access Button is currently funded by <a href="https://blog.openaccessbutton.org/arcadia-fund-supports-open-access-button-to-improve-access-to-research-without-subscriptions-b7c36b3e1a6e">Arcadia – a charitable fund of Lisbet Rausing and Peter Baldwin</a>.
     </p>
     <p>
-      Alongslide active team members, many have <a href="/alumni">come and gone from the project</a> and contributed critical work. Thanks to <a href="https://www.jisc.ac.uk/" target="_blank">Jisc</a>, <a href="https://www.opensocietyfoundations.org/" target="_blank">Open Society Foundations</a>, <a href="https://cos.io">Center for Open Science</a>, and others for their support.
+      Alongside active team members, many have <a href="/alumni">come and gone from the project</a> and contributed critical work. Thanks to <a href="https://www.jisc.ac.uk/" target="_blank">Jisc</a>, <a href="https://www.opensocietyfoundations.org/" target="_blank">Open Society Foundations</a>, <a href="https://cos.io">Center for Open Science</a>, and others for their support.
     </p>
 
     <p>


### PR DESCRIPTION
Just spotted this typo while browsing the website.